### PR TITLE
add stack and stderr to restart detail

### DIFF
--- a/src/process-monitor.js
+++ b/src/process-monitor.js
@@ -37,7 +37,7 @@ function checkProcess(timeoutScheduler) {
     }
 
     if (notFound) {
-      logger.external("no player watchdog", "restarting");
+      logger.external("no player watchdog", `restarting | ${stack} ${stderr}`);
       timeoutScheduler(starter.restart, fiveSeconds);
       return;
     }


### PR DESCRIPTION
This is an attempt to gather more info for https://trello.com/c/kjFlcs0f/4409-2-investigate-displays-restarted-by-watchdog-module-with-no-errors-in-logs

So far, all the displays that present this behavior are Windows 10 32 bits, so there may be something odd with the execution of the command that looks for the player watcdog on these environments ( though it does not happen on our Uptime win 10 32 ). This change prints additional information on the execution of that command when a restart is to be performed.
