### PR TITLE
don't restart player if external command execution failed

### DIFF
--- a/src/process-monitor.js
+++ b/src/process-monitor.js
@@ -32,7 +32,7 @@ function checkProcess(timeoutScheduler) {
 
     if (found) {return;}
 
-    if (otherCommandError) {
+    if (otherCommandError || stack && stack.startsWith('Error: Command failed')) { // eslint-disable-line no-mixed-operators
       return logger.external("process monitor error", `${stack} ${stderr}`);
     }
 

--- a/test/unit/process-monitor.js
+++ b/test/unit/process-monitor.js
@@ -93,6 +93,21 @@ describe("Process Monitor - Unit", ()=>{
     assert.equal(starter.restart.callCount, 0);
   });
 
+  it("should log when the command fails, even if code is 1", () => {
+    simple.mock(childProc, "exec").callFn((cmd, opts, cb)=>{
+      cb({
+        code: 1,
+        stack: "Error: Command failed: wmic process get commandline |findstr asar\\watchdog ERROR: Description = Invalid namespace at ChildProcess.exithandler (child_process.js:223:12)"
+      }, "", "");
+    });
+
+    monitor.init(0, scheduler);
+
+    assert.equal(logger.external.lastCall.args[0], "process monitor error");
+    assert.equal(logger.external.callCount, 1);
+    assert.equal(starter.restart.callCount, 0);
+  });
+
   it("should log unexpected state if stdout is empty after successful command", () => {
     simple.mock(childProc, "exec").callFn((cmd, opts, cb)=>{
       cb({code: 0}, "", "");


### PR DESCRIPTION
There are some displays where watchdog external command execution fails with code 1, but an error like

-  Error: Command failed: wmic process get commandline |findstr asar\\watchdog ERROR: Description = Invalid namespace

as the error code is 1, this is currently interpreted as a restart condition, and thus the player is restarted in these displays even if it may not be needed. In some cases, this happens constantly.

With this fix, the error is logged, but the player is not restarted in those cases.
